### PR TITLE
V0.16.5 Short Node Names

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Scraper - A Composable Workflow Framework
 =========================================
 
-![version](https://img.shields.io/badge/version-0.16.4-green.svg)
+![version](https://img.shields.io/badge/version-0.16.5-green.svg)
 ![language](https://img.shields.io/badge/language-java11+(JPMS)-blue.svg)
 ![build](https://img.shields.io/badge/build-gradle-yellowgreen.svg)
 

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id("de.jjohannes.extra-java-module-info") version "0.1"
 }
 
-version = '0.16.4'
+version = '0.16.5'
 
 extraJavaModuleInfo {
     module("antlr4-runtime-4.8.jar", "org.antlr.antlr4.runtime", "4.8") {}

--- a/application/src/test/java/scraper/app/SimpleSystemTest.java
+++ b/application/src/test/java/scraper/app/SimpleSystemTest.java
@@ -129,4 +129,12 @@ public class SimpleSystemTest {
         assertTrue(ff.exists());
         Scraper.main(new String[]{ff.getAbsolutePath()});
     }
+
+    @Test
+    public void noNodeTest() throws Exception {
+        URL f = Scraper.class.getResource("nonode.yf");
+        File ff = new File(f.toURI());
+        assertTrue(ff.exists());
+        Scraper.main(new String[]{ff.getAbsolutePath()});
+    }
 }

--- a/application/src/test/resources/scraper/app/nonode.yf
+++ b/application/src/test/resources/scraper/app/nonode.yf
@@ -1,0 +1,11 @@
+---
+name: addr
+
+graphs:
+  start:
+    - type: Echo
+      goTo: "next-node"
+
+    - type: echo
+      label: "next-node"
+

--- a/core-plugins/src/main/java/scraper/plugins/core/flowgraph/GraphVisualizer.java
+++ b/core-plugins/src/main/java/scraper/plugins/core/flowgraph/GraphVisualizer.java
@@ -93,7 +93,7 @@ public class GraphVisualizer {
             return
                     (includeInstance ? adr.getInstance()+"\\n" : "") +
                             (includeGraph ? adr.getGraph()+"\\n" : "") +
-                            (includeNodeType ? simpleName+"\\n<" : "") +
+                            (includeNodeType ? simpleName+"\\n" : "") +
                             (includeNodeAddress ? "<"+ adr.getNode() +">": "")
                     +""
                     ;

--- a/core-plugins/src/test/java/scraper/plugins/core/typechecker/helper/TestRecExtractNode.java
+++ b/core-plugins/src/test/java/scraper/plugins/core/typechecker/helper/TestRecExtractNode.java
@@ -9,6 +9,7 @@ import scraper.api.node.type.FunctionalNode;
 import scraper.api.template.L;
 import scraper.api.template.T;
 
+/** Custom class extract node */
 @NodePlugin(value = "0.0.1", deprecated = true)
 public class TestRecExtractNode implements FunctionalNode {
 

--- a/core/src/main/java/scraper/core/JobFactory.java
+++ b/core/src/main/java/scraper/core/JobFactory.java
@@ -186,7 +186,9 @@ public class JobFactory {
             int i = 0;
 
             for (Map<String, Object> nodeConfiguration : graph) {
-                String nodeType = (String) nodeConfiguration.get("type");
+                String beforeNodeType = (String) nodeConfiguration.get("type");
+                if (!beforeNodeType.endsWith("Node")) beforeNodeType = beforeNodeType + "Node";
+                String nodeType = beforeNodeType;
                 String nodeAddress = (String) nodeConfiguration.get("label");
 
                 String vers = jobNodeDependencies
@@ -198,6 +200,7 @@ public class JobFactory {
                         .stream()
                         .filter(p -> p.supports(nodeType, vers))
                         .collect(Collectors.toList());
+
                 Node n = getHighestMatchingPlugin(processPlugins, nodeType, vers);
 
                 NodeContainer<? extends Node> nn = getMatchingNodeContainer(


### PR DESCRIPTION
* Allow short node names to be used in the specification
  * `Echo`/`echo` instead of `EchoNode`
* Removed erroneous addition of "<" symbol for graph visualizer for certain flags

Resolves #16.